### PR TITLE
Adding ec2_deploy_multiple task.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -176,14 +176,14 @@ grunt ec2_deploy:teddy
 
 ![ec2-deploy.png][4]
 
-## Deploy to multiple EC2 instances `ec2_deploy_multiple`
+## Deploy to multiple EC2 instances `ec2_deploy_many`
 
 Queries EC2 for instances that match the given name and deploys to each on using `ec2_deploy`.
 
 Example:
 
 ```shell
-grunt ec2_deploy_multiple:teddy*
+grunt ec2_deploy_many:teddy*
 ```
 
 ## Reboot an instance with `ec2_reboot`
@@ -211,6 +211,7 @@ Task and Target(s)|Purpose
 `ec2_delete_tag:id`|Deletes the associated name tag for an instance
 `ec2_rename_tag:old:replacement`|Tags an instance using a different name
 `ec2_deploy:name`|Deploys to the instance using `rsync`, reloads `pm2` and `nginx`
+`ec2_deploy_many:name`|Gets instances filtered by name tag and deploys to the instance using `rsync`, reloads `pm2` and `nginx`
 `ec2_elb_attach:instance-name:elb-name?`|Attaches an instance to an ELB
 `ec2_elb_detach:instance-name:elb-name?`|Detaches an instance from an ELB
 `ec2_launch:name`|Creates a new instance, giving it a key-pair, a name tag, and an IP. Then sets it up

--- a/tasks/ec2_deploy_many.js
+++ b/tasks/ec2_deploy_many.js
@@ -7,13 +7,13 @@ var conf = require('./lib/conf.js');
 
 module.exports = function (grunt) {
 
-    grunt.registerTask('ec2_deploy_multiple', 'Deploys multiple Instances', function (name) {
+    grunt.registerTask('ec2_deploy_many', 'Deploys multiple Instances', function (name) {
         conf.init(grunt);
 
         if (arguments.length === 0) {
             grunt.fatal([
                 'You should provide an instance name.',
-                'e.g: ' + chalk.yellow('grunt ec2_deploy_multiple:name')
+                'e.g: ' + chalk.yellow('grunt ec2_deploy_many:name')
             ].join('\n'));
         }
 
@@ -31,12 +31,12 @@ module.exports = function (grunt) {
 
             var instanceNames = [];
             for (var i = 0; i < flat.length; i++) {
-                instanceNames.push(flat[i]["Tags"][0]["Value"]);
+                instanceNames.push(flat[i]['Tags'][0]['Value']);
             }
 
             grunt.log.writeln('Deploying to instances: %s', chalk.cyan(instanceNames));
 
-            for (var i = 0; i < instanceNames.length; i++) {
+            for (var j = 0; j < instanceNames.length; j++) {
                 grunt.task.run('ec2_deploy:' + instanceNames[i]);
             }
 


### PR DESCRIPTION
Didn't see an easy way to deploy to multiple instances, so added an ec2_deploy_multiple task that queries aws using the same logic as ec2_lookup_json, then grabs the instance names from the resulting json and passes them to ec2_deploy.
