### PR TITLE
chown after rsync upload in deployment

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -96,7 +96,8 @@ Variable Name|Purpose
 `"SSL_STRICT"`|Whether to send a `Strict-Transport-Security` header.
 `"VERBOSITY_NPM"`|Determines the output verbosity for `npm` during deployments, values are limited to `loglevel` option values for `npm`. Defaults to `info`, just like `npm` does.
 `"VERBOSITY_RSYNC"`|Determines the output verbosity for `rsync`. Possible values limited to `'v'`, `'vv'`, and `'vvv'`. Defaults to `''` (not verbose at all, my friend).
- `"PM2_INSTANCES_COUNT"`| Set number processes to start with pm2. default is 2 and valid values are integers or 'max' for setting the maximum processes depending on avaible CPUs
+ `"PM2_INSTANCES_COUNT"`| Set number processes to start with pm2. default is 2 and valid values are integers or 'max' for setting the maximum processes depending on avaible CPUs.
+ `"PM2_MODE"`| If set to `'fork'`, lauches pm2 with the param `'-x'` instead of cluster mode. This is a workaround for Node v0.10.x as pm2 does not work well with this version of node. If you are using Node 0.11.x you shuold prefer using cluster mode (default) and avoid setting this param. More on this subject: https://github.com/Unitech/PM2/issues/74
 
 # Tasks
 

--- a/tasks/lib/commands.js
+++ b/tasks/lib/commands.js
@@ -20,8 +20,14 @@ module.exports = {
         // user can override NODE_ENV if need be
         _.assign(env, defaults, user);
 
-        return util.format('%s || sudo %s pm2 start %s/%s -i %s --name %s || echo "pm2 already started."',
-            running, parse.toPairs(env), conf('SRV_CURRENT'), conf('NODE_SCRIPT'), conf('PM2_INSTANCES_COUNT'), name
+        // if PM2_MODE is conf to 'fork', run pm2 with -x param: https://github.com/Unitech/PM2/issues/74
+        // For Node v0.10.x the workaround is now to launch your script in "fork mode" by adding the -x parameter 
+        var pmMode = "";
+        if(conf('PM2_MODE') == 'fork'){
+            pmMode = "-x"
+        }
+        return util.format('%s || sudo %s pm2 start %s/%s -i %s --name %s %s || echo "pm2 already started."',
+            running, parse.toPairs(env), conf('SRV_CURRENT'), conf('NODE_SCRIPT'), conf('PM2_INSTANCES_COUNT'), name, pmMode
         );
     }
 };

--- a/tasks/lib/workflow.js
+++ b/tasks/lib/workflow.js
@@ -43,7 +43,10 @@ function api (steps, options, done) {
             var parent = path.relative(path.dirname(r.local), r.local);
             var remoteSync = util.format('%s%s', r.remote, parent ? '/' + parent : '');
 
-            ssh([ util.format('sudo cp -r %s/* %s', remoteSync, r.dest) ], options, next);
+            ssh([ util.format('sudo cp -r %s/* %s', remoteSync, r.dest) ], options, chown);
+        }
+        function chown(){
+             ssh([ util.format('sudo chown -R %s:%s %s',conf('AWS_SSH_USER') ,conf('AWS_SSH_USER'),r.dest) ], options, next);
         }
     }, done);
 


### PR DESCRIPTION
the problem is that rsync uploads and creates folders :/srv/apps/ec2/v/0.0.9 with the root user(sudo) and the application runs with the ubuntu user. 
this is not a good solution if your application needs to create temporary data in the project's folder
with this fix a chown -R ubuntu:ubuntu is run after the upload

let me know what do you think,
thx
