### PR TITLE
Fix pm2 install and startup

### DIFF
--- a/tasks/ec2_setup.js
+++ b/tasks/ec2_setup.js
@@ -60,8 +60,8 @@ module.exports = function (grunt) {
             'sudo apt-get install nodejs -y'
         ], [ // pm2
             'sudo apt-get install make g++ -y',
-            'sudo npm install -g pm2',
-            'sudo pm2 startup'
+            'sudo npm install -g pm2 --unsafe-perm',
+            'sudo pm2 startup ubuntu'
         ]];
 
         function forwardPort(from, to) {


### PR DESCRIPTION
- Add --unsafe-perm to successfully install pm2
- Add ubuntu platform at pm2 startup (fixes #12)
