### PR TITLE
Fix the "Pending Instance is not in a valid state " issue

### DIFF
--- a/tasks/ec2_assign_existing_address.js
+++ b/tasks/ec2_assign_existing_address.js
@@ -26,14 +26,15 @@ module.exports = function (grunt) {
 
         aws.log('ec2 associate-address --instance-id %s --public-ip %s', id, ip);
         var waitForParams = {
-          InstanceIds:  [id]
+            InstanceIds:  [id]
         };
         aws.ec2.waitFor('instanceRunning', waitForParams, function(err, data) {
-          if (err) {
-              console.log(err, err.stack); // an error occurred
-              return;
-          }
-          aws.ec2.associateAddress(params, aws.capture('Instance associated with public IP.', done));
+            if (err) {
+                console.log(err, err.stack); // an error occurred
+                return;
+            }
+            console.log(data); // succesful response
+            aws.ec2.associateAddress(params, aws.capture('Instance associated with public IP.', done));
         });
     });
 };

--- a/tasks/ec2_assign_existing_address.js
+++ b/tasks/ec2_assign_existing_address.js
@@ -25,6 +25,15 @@ module.exports = function (grunt) {
         };
 
         aws.log('ec2 associate-address --instance-id %s --public-ip %s', id, ip);
-        aws.ec2.associateAddress(params, aws.capture('Instance associated with public IP.', done));
+        var waitForParams = {
+          InstanceIds:  [id]
+        };
+        aws.ec2.waitFor('instanceRunning', waitForParams, function(err, data) {
+          if (err) {
+              console.log(err, err.stack); // an error occurred
+              return;
+          }
+          aws.ec2.associateAddress(params, aws.capture('Instance associated with public IP.', done));
+        });
     });
 };


### PR DESCRIPTION
Fix issue: https://github.com/bevacqua/grunt-ec2/issues/15
This fix use ec2.waitFor to wait until instance starts to run before
trying to associate ip address
